### PR TITLE
Update README.md to fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gem "rubocop-rails_config"
 
 ## Usage
 
-Add this line to your application's `.rubocop.yml`, or just run `rails generate rubocop_rails:install`:
+Add this line to your application's `.rubocop.yml`, or just run `rails generate rubocop_rails_config:install`:
 
 ```yml
 inherit_gem:


### PR DESCRIPTION
The command provided in README to bootstrap the config is not correct (seems to be legacy from "rubocop-rails").