### PR TITLE
Update Exclude Setting

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -9,6 +9,10 @@ AllCops:
     - 'actionpack/lib/action_dispatch/journey/parser.rb'
     - 'railties/test/fixtures/tmp/**/*'
     - 'node_modules/**/*'
+    # rubocop default exclude
+    - 'node_modules/**/*'
+    - 'vendor/**/*'
+    - '.git/**/*'
     # Additional exclude files by rubocop-rails_config
     - 'db/migrate/**/*.rb'
     - 'db/*.rb'

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -10,12 +10,12 @@ AllCops:
     - 'railties/test/fixtures/tmp/**/*'
     - 'node_modules/**/*'
     # rubocop default exclude
-    - 'node_modules/**/*'
-    - 'vendor/**/*'
     - '.git/**/*'
     # Additional exclude files by rubocop-rails_config
-    - 'db/migrate/**/*.rb'
+    - 'bin/*'
+    - 'config/initializers/*.rb'
     - 'db/*.rb'
+    - 'db/migrate/**/*.rb'
 
 Performance:
   Exclude:


### PR DESCRIPTION
ref. https://github.com/toshimaru/rubocop-rails/issues/15

After running `rails app:update`,  it generates many files which have rubocop offense. Let's ignore the files.