### PR TITLE
Unify the notation of RuboCop

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 RuboCop configuration which has the same code style checking as official Ruby on Rails.
 
-[Official RoR Rubocop Configuration](https://github.com/rails/rails/blob/master/.rubocop.yml)
+[Official RoR RuboCop Configuration](https://github.com/rails/rails/blob/master/.rubocop.yml)
 
 ## Installation
 


### PR DESCRIPTION
RubyCop is the proper notation as below.

> **RuboCop** is a Ruby static code analyzer and code formatter.
> Out of the box it will enforce many of the guidelines outlined
> in the community Ruby Style Guide.

https://github.com/rubocop-hq/rubocop/blob/v0.65.0/README.md