### PR TITLE
Follow rename from rubocop 0.68.0

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -77,7 +77,7 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Enabled: true
 
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.


### PR DESCRIPTION
Fixes #42

It was renamed in rubocop `0.68.0`

 https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0680-2019-04-29