### PR TITLE
Enable `Layout/EmptyLinesAroundAccessModifier` cop

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -61,6 +61,10 @@ Layout/EndAlignment:
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
 
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+  EnforcedStyle: only_before
+
 Layout/EmptyLinesAroundBlockBody:
   Enabled: true
 

--- a/lib/generators/rubocop_rails_config/install_generator.rb
+++ b/lib/generators/rubocop_rails_config/install_generator.rb
@@ -14,7 +14,6 @@ module RubocopRailsConfig
       end
 
     private
-
       def config_file_exists?
         File.exist?(config_file_path)
       end

--- a/lib/generators/rubocop_rails_config/update_generator.rb
+++ b/lib/generators/rubocop_rails_config/update_generator.rb
@@ -17,7 +17,6 @@ module RubocopRailsConfig
       end
 
     private
-
       # rubocop-rails is renamed to rubocop-rails_config
       def old_gem_name_used?
         File.foreach(config_file_path).grep(/\s+rubocop-rails:/).any?


### PR DESCRIPTION
### Summary

Follow up https://github.com/rails/rails/pull/36472.

This PR enables `Layout/EmptyLinesAroundAccessModifier` cop with `EnforcedStyle: only_before`.

### Other Information

This enforced style was introduced with RuboCop 0.70.
https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0700-2019-05-21