### PR TITLE
Exclude bin/ db/ and config/ from Lint

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -15,6 +15,9 @@ AllCops:
     - 'actionmailbox/test/dummy/**/*'
     - 'actiontext/test/dummy/**/*'
     - '**/node_modules/**/*'
+    - 'bin/**/*'
+    - 'config/**/*'
+    - 'db/**/*'
 
 Performance:
   Exclude:


### PR DESCRIPTION
Just a reintroduction.
This was removed with the last update.

I would like to reintroduce it for several reasons:

* rubocop now complains about Migrations but I can't change them because you never change Migrations.
    * Also they are generated and not written by humans most of the Time.
* Rubocop complaint about db/schema.rb (missing Frozen String Literal) and you should never change that File by Hand...
* bin/* Files are also not written by Humans most of the Time. I see no reason to Lint them.
* Mostly same for the Files in config/ (but I could Argue on those...)