### PR TITLE
Support RuboCop 0.76

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ rvm:
   - 2.6.3
 # Put this in your .travis.yml
 gemfile:
-  - gemfiles/rubocop_0.74.gemfile
+  - gemfiles/rubocop_0.76.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-appraise "rubocop-0.74" do
-  gem "rubocop", "~> 0.74"
+appraise "rubocop-0.76" do
+  gem "rubocop", "~> 0.76"
   gem "rails"
 end

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -180,7 +180,7 @@ Layout/TrailingWhitespace:
   Enabled: true
 
 # Use quotes for string literals when they are enough.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 Lint/AmbiguousOperator:

--- a/gemfiles/rubocop_0.76.gemfile
+++ b/gemfiles/rubocop_0.76.gemfile
@@ -4,7 +4,7 @@
 
 source "https://rubygems.org"
 
-gem "rubocop", "~> 0.74"
+gem "rubocop", "~> 0.76"
 gem "rails"
 
 gemspec path: "../"

--- a/rubocop-rails_config.gemspec
+++ b/rubocop-rails_config.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.license               = "MIT"
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "rubocop", "~> 0.74"
+  spec.add_dependency "rubocop", "~> 0.76"
   spec.add_dependency "rubocop-performance", "~> 1.3"
   spec.add_dependency "rubocop-rails", "~> 2.0"
   spec.add_dependency "railties", ">= 3.0"


### PR DESCRIPTION
Fixes #56.

This PR supports RuboCop 0.76 and renames `Style/UnneededPercentQ` cop to `Style/RedundantPercentQ` cop.

https://github.com/rails/rails/pull/37582 has not yet been merged.
However, this change is absolutely necessary. So, I'd like to merge and release first for the convenience of rubocop-rails_config users.