### PR TITLE
Drop support for Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: bundler
 before_install:
   - gem install bundler || gem install bundler -v 1.17.3
 rvm:
-  - 2.3.7
   - 2.4.6
   - 2.5.5
   - 2.6.3

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ rails generate rubocop_rails_config:install
 
 ### TargetRubyVersion
 
-Although Rails 6 only supports Ruby 2.5 or more, rubocop-rails_config still supports Ruby 2.3 or more to support as many Ruby versions as possible.
+Although Rails 6 only supports Ruby 2.5 or more, rubocop-rails_config still supports Ruby 2.4 or more to support as many Ruby versions as possible.
 
 If you'd like to change `TargetRubyVersion`, see [Customization](#customization).
 

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -3,8 +3,8 @@ require:
   - rubocop-rails
 
 AllCops:
-  # rubocop-rails_config still supports Ruby 2.3
-  TargetRubyVersion: 2.3
+  # rubocop-rails_config still supports Ruby 2.4
+  TargetRubyVersion: 2.4
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true

--- a/rubocop-rails_config.gemspec
+++ b/rubocop-rails_config.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.files                 = Dir["README.md", "LICENSE", "config/*.yml", "lib/**/*"]
   spec.homepage              = "https://github.com/toshimaru/rubocop-rails_config"
   spec.license               = "MIT"
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_dependency "rubocop", "~> 0.80"
   spec.add_dependency "rubocop-performance", "~> 1.3"


### PR DESCRIPTION
RuboCop 0.82 has been released. It drops Ruby 2.3.
https://github.com/rubocop-hq/rubocop/releases/tag/v0.82.0