### PR TITLE
Bump RuboCop::Packaging to v0.5

### DIFF
--- a/rubocop-rails_config.gemspec
+++ b/rubocop-rails_config.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop-ast", ">= 1.0.1"
   spec.add_dependency "rubocop-performance", "~> 1.3"
   spec.add_dependency "rubocop-rails", "~> 2.0"
-  spec.add_dependency "rubocop-packaging", "~> 0.4"
+  spec.add_dependency "rubocop-packaging", "~> 0.5"
   spec.add_dependency "railties", ">= 5.0"
 end


### PR DESCRIPTION
Hi @toshimaru,

RuboCop::Packaging through v0.5 supports
autocorrect for its cops. Thus worth bumping
the version from v0.4 to v0.5.

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>