### PR TITLE
Disable `Lint/ShadowingOuterLocalVariable` cop

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -209,9 +209,6 @@ Lint/ErbNewArguments:
 Lint/RequireParentheses:
   Enabled: true
 
-Lint/ShadowingOuterLocalVariable:
-  Enabled: true
-
 Lint/RedundantStringCoercion:
   Enabled: true
 


### PR DESCRIPTION
Follow https://github.com/rails/rails/commit/ba97e9f918bc2ffe8ed351a0e0b8d75b67d26086.

"shadowing outer local variable" warning was removed in Ruby 2.6.

- ruby/ruby@c9d720b
- https://bugs.ruby-lang.org/issues/12490

rubocop-rails_config supports Ruby 2.4, however rubocop-rails_config is rails/rails repo compliant. If Ruby 2.5 or lower users need `Lint/ShadowingOuterLocalVariable` warning, it can be enabled on the application side.