### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ rails generate rubocop_rails_config:install
 
 ### TargetRubyVersion
 
-Although Rails 6 only supports Ruby 2.5 or more, rubocop-rails_config still supports Ruby 2.4 or more to support as many Ruby versions as possible.
+Although Rails 7 (edge) only supports Ruby 2.7 or more, rubocop-rails_config still supports Ruby 2.4 or more to support as many Ruby versions as possible.
 
 If you'd like to change `TargetRubyVersion`, see [Customization](#customization).
 


### PR DESCRIPTION
Rails 7 (edge) requires Ruby 2.7 or higher. 

- https://github.com/rails/rails/commit/6487836af8f50648a9b30ce61864c827132e5592
- https://github.com/rails/rails/commit/2e9c0e04c57d386b12ccaad1f23c3484bee3f8a0

But rubocop-rails_config still supports Ruby 2.4 or more to support as many Ruby versions as possible.