### PR TITLE
Exclude only schema.rb in db directory

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -20,7 +20,7 @@ AllCops:
     # Additional exclude files by rubocop-rails_config
     - 'bin/**/*'
     - 'config/**/*'
-    - 'db/**/*'
+    - 'db/schema.rb'
 
 Performance:
   Exclude:


### PR DESCRIPTION
Follow https://github.com/toshimaru/rubocop-rails_config/pull/48.

I think it is reasonable that auto-generated `db/schema.rb` is excluded by default. But `db/migrate/*.rb` will be user-written and I think `db/**/*` is too wide range.
I noticed that cops couldn't detect offenses because entire `db` directory has been excluded. So, this PR defaults to excluding only `schema.rb` in `db` directory.