### PR TITLE
Include config directory by default

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -20,7 +20,6 @@ AllCops:
     - '**/node_modules/**/*'
     # Additional exclude files by rubocop-rails_config
     - 'bin/**/*'
-    - 'config/**/*'
     - 'db/schema.rb'
 
 Performance:


### PR DESCRIPTION
`config` directory contains files that user can write, such as `application.rb`, `environments/*.rb`, and so on.
Like #104, I think these are targets that should be detected offenses by default.