### PR TITLE
Relax `TargetRubyVersion`

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -4,8 +4,6 @@ require:
   - rubocop-rails
 
 AllCops:
-  # rubocop-rails_config still supports Ruby 2.4
-  TargetRubyVersion: 2.4
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true


### PR DESCRIPTION
The next version of RuboCop will drop Ruby 2.4 support.
https://github.com/rubocop/rubocop/pull/9648

This PR prevents the following error with edge RuboCop (and next stable RuboCop).

```console
% bundle exec rubocop --parallel
Error: RuboCop found unsupported Ruby version 2.4 in `TargetRubyVersion`
parameter (in /Users/koic/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/
rubocop-rails_config-1.4.0/config/rails.yml).
2.4-compatible analysis was dropped after version 1.12.
Supported versions: 2.5, 2.6, 2.7, 3.0
```

The minimum Ruby supported version of the next RuboCop is 2.5.

I think it would be beneficial for both UX and maintainability to omit `TargetRubyVersion` and delegate it to RuboCop core.