### PR TITLE
Enable `Performance/MapCompact` cop

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -255,6 +255,9 @@ Performance/BindCall:
 Performance/FlatMap:
   Enabled: true
 
+Performance/MapCompact:
+  Enabled: true
+
 Performance/RedundantMerge:
   Enabled: true
 

--- a/rubocop-rails_config.gemspec
+++ b/rubocop-rails_config.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rubocop", ">= 1.13"
   spec.add_dependency "rubocop-ast", ">= 1.0.1"
-  spec.add_dependency "rubocop-performance", "~> 1.3"
+  spec.add_dependency "rubocop-performance", "~> 1.11"
   spec.add_dependency "rubocop-rails", "~> 2.0"
   spec.add_dependency "rubocop-packaging", "~> 0.5"
   spec.add_dependency "railties", ">= 5.0"


### PR DESCRIPTION
Follow https://github.com/rails/rails/commit/bbbc861

This PR enables `Performance/MapCompact` cop and requires RuboCop Performance 1.11 or higher.
Because `Performance/MapCompact` cop has introduced in RuboCop Performance 1.11.