### PR TITLE
Enable four Performance cops

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -314,5 +314,17 @@ Performance/DeleteSuffix:
 Performance/OpenStruct:
   Enabled: true
 
+Performance/InefficientHashSearch:
+  Enabled: true
+
+Performance/ConstantRegexp:
+  Enabled: true
+
+Performance/RedundantStringChars:
+  Enabled: true
+
+Performance/StringInclude:
+  Enabled: true
+
 Minitest/UnreachableAssertion:
   Enabled: true


### PR DESCRIPTION
Follow up https://github.com/rails/rails/pull/45865

This PR enables `Performance/InefficientHashSearch`,  `Performance/ConstantRegexp`, `Performance/RedundantStringChars`, and `Performance/StringInclude`.