### PR TITLE
Set the required_ruby_version to 2.7+

### DIFF
--- a/rubocop-rails_config.gemspec
+++ b/rubocop-rails_config.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.files                 = Dir["README.md", "LICENSE", "config/*.yml", "lib/**/*"]
   spec.homepage              = "https://github.com/toshimaru/rubocop-rails_config"
   spec.license               = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.add_dependency "rubocop", ">= 1.48.0"
   spec.add_dependency "rubocop-ast", ">= 1.26.0"


### PR DESCRIPTION
Follow up https://github.com/toshimaru/rubocop-rails_config/pull/161.

This PR sets the required_ruby_version to 2.7+.