### PR TITLE
Enable `Minitest/LiteralAsActualArgument` cop

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -351,6 +351,9 @@ Minitest/AssertRaisesWithRegexpArgument:
 Minitest/AssertWithExpectedArgument:
   Enabled: true
 
+Minitest/LiteralAsActualArgument:
+  Enabled: true
+
 Minitest/SkipEnsure:
   Enabled: true
 


### PR DESCRIPTION
Follow up https://github.com/rails/rails/pull/49236.

This PR enables `Minitest/LiteralAsActualArgument` cop.