### PR TITLE
Fix a build error

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,10 @@ RuboCop::RakeTask.new
 
 task :rails_test do
   RAILS_TEST_DIR = "rails_test"
-  EXCEPT_COPS = ["Style/StringLiterals", "Style/FrozenStringLiteralComment"].freeze
+
+  # TODO: By using Rails that includes https://github.com/rails/rails/pull/49247,
+  #       the specification for 'Layout/EmptyLinesAroundBlockBody' becomes unnecessary.
+  EXCEPT_COPS = ["Layout/EmptyLinesAroundBlockBody", "Style/StringLiterals", "Style/FrozenStringLiteralComment"].freeze
 
   sh "rails new #{RAILS_TEST_DIR} --skip-webpack-install"
   cp "./test/fixture/.rubocop.yml", "#{RAILS_TEST_DIR}/.rubocop.yml"


### PR DESCRIPTION
This PR fixes the following build error:

```console
(snip)
rubocop --except=Style/StringLiterals,Style/FrozenStringLiteralComment .
cp ./test/fixture/.rubocop.yml rails_test/.rubocop.yml
cd rails_test
Inspecting 28 files
C...........................

Offenses:

Gemfile:71:1: C: [Correctable] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end.

28 files inspected, 1 offense detected, 1 offense autocorrectable
rake aborted!
```

https://github.com/toshimaru/rubocop-rails_config/actions/runs/6167995304/job/16739825926

This is a regression in Rails 7.0.8, which will be resolved by https://github.com/rails/rails/pull/49247. Until then, specifying the `Layout/EmptyLinesAroundBlockBody` cop is a workaround to prevent the build error.