### PR TITLE
Revert "Add rubocop-md"

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -3,7 +3,6 @@ require:
   - rubocop-packaging
   - rubocop-performance
   - rubocop-rails
-  - rubocop-md
 
 AllCops:
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
@@ -16,15 +15,8 @@ AllCops:
     - '**/vendor/**/*'
     - 'actionpack/lib/action_dispatch/journey/parser.rb'
     - 'actionmailbox/test/dummy/**/*'
-    - 'activestorage/test/dummy/**/*'
     - 'actiontext/test/dummy/**/*'
     - '**/node_modules/**/*'
-    - '**/CHANGELOG.md'
-    - '**/2_*_release_notes.md'
-    - '**/3_*_release_notes.md'
-    - '**/4_*_release_notes.md'
-    - '**/5_*_release_notes.md'
-    - '**/6_*_release_notes.md'
     # Additional exclude files by rubocop-rails_config
     - 'bin/**/*'
     - 'db/schema.rb'
@@ -111,8 +103,6 @@ Style/HashSyntax:
 Layout/IndentationConsistency:
   Enabled: true
   EnforcedStyle: indented_internal_methods
-  Exclude:
-    - '**/*.md'
 
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:
@@ -170,7 +160,6 @@ Style/FrozenStringLiteralComment:
     - 'activestorage/db/update_migrate/**/*.rb'
     - 'actionmailbox/db/migrate/**/*.rb'
     - 'actiontext/db/migrate/**/*.rb'
-    - '**/*.md'
 
 Style/MapToHash:
   Enabled: true
@@ -362,9 +351,3 @@ Minitest/SkipEnsure:
 
 Minitest/UnreachableAssertion:
   Enabled: true
-
-Markdown:
-  # Whether to run RuboCop against non-valid snippets
-  WarnInvalid: false
-  # Whether to lint codeblocks without code attributes
-  Autodetect: false

--- a/rubocop-rails_config.gemspec
+++ b/rubocop-rails_config.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rubocop", ">= 1.48.0"
   spec.add_dependency "rubocop-ast", ">= 1.26.0"
-  spec.add_dependency "rubocop-md"
   spec.add_dependency "rubocop-minitest", "~> 0.22"
   spec.add_dependency "rubocop-packaging", "~> 0.5"
   spec.add_dependency "rubocop-performance", "~> 1.11"


### PR DESCRIPTION
This reverts commit a30ef798c9d42750fad9ed5958a850d5382e015e.

`rubocop-md` is a unique gem that doesn't possess any cops. It inspects Ruby code within Markdown files. However, as can be seen from the disabling of cops in `rails/rails`, which cops to disable is documented in the inspection target repository:

```diff
  Exclude:
+   - '**/CHANGELOG.md'
+   - '**/2_*_release_notes.md'
+   - '**/3_*_release_notes.md'
+   - '**/4_*_release_notes.md'
+   - '**/5_*_release_notes.md'
+   - '**/6_*_release_notes.md'

 Layout/IndentationConsistency:
   Enabled: true
   EnforcedStyle: indented_internal_methods
+  Exclude:
+    - '**/*.md'

 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always
   Exclude:
     - 'actionview/test/**/*.builder'
     - 'actionview/test/**/*.ruby'
     - 'actionpack/test/**/*.builder'
     - 'actionpack/test/**/*.ruby'
     - 'activestorage/db/migrate/**/*.rb'
     - 'activestorage/db/update_migrate/**/*.rb'
     - 'actionmailbox/db/migrate/**/*.rb'
     - 'actiontext/db/migrate/**/*.rb'
+    - '**/*.md'
```

This means that any false positives in documentation need to be addressed as they arise, leading one to question whether this is the behavior users expect.

This PR resolves the above-mentioned usability issues by disabling `rubocop-md`. If users wish to enable `rubocop-md`, they simply need to add it explicitly to their `.rubocop.yml`. In other words, the use of `rubocop-md` is a deliberate choice made by the user.

I believe this is a better configuration for `rubocop-rails_config`.