### PR TITLE
Remove railties from runtime dependencies

### DIFF
--- a/rubocop-rails_config.gemspec
+++ b/rubocop-rails_config.gemspec
@@ -19,5 +19,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop-packaging", "~> 0.5"
   spec.add_dependency "rubocop-performance", "~> 1.11"
   spec.add_dependency "rubocop-rails", "~> 2.0"
-  spec.add_dependency "railties", ">= 5.0"
 end


### PR DESCRIPTION
`bundle update rubocop-rails_config` unexpectedly upgrades `zweitwerk`, a dependency of `railties` (Dependabot as well). This PR removes `railties` from the runtime dependencies to prevent such unintended gem upgrades.