### PR TITLE
Workaround to prevent the following error in RuboCop Rails 2.21.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,7 @@ gem "bundler"
 gem "minitest"
 gem "rake"
 gem "rails", ">= 5.2"
+# This is a workaround to prevent the following error in RuboCop Rails 2.21.2.
+# https://github.com/toshimaru/rubocop-rails_config/actions/runs/6522833241/job/17712818757#step:4:85
+# This gem specification can be removed once a version resolving the issue is released.
+gem "rubocop-rails", "2.21.1"

--- a/gemfiles/rubocop_1.48.gemfile
+++ b/gemfiles/rubocop_1.48.gemfile
@@ -10,5 +10,9 @@ gem "minitest"
 gem "rake"
 gem "rails", ">= 5.2"
 gem "rubocop", "~> 1.48.0"
+# This is a workaround to prevent the following error in RuboCop Rails 2.21.2.
+# https://github.com/toshimaru/rubocop-rails_config/actions/runs/6522833241/job/17712818757#step:4:85
+# This gem specification can be removed once a version resolving the issue is released.
+gem "rubocop-rails", "2.21.1"
 
 gemspec path: "../"

--- a/gemfiles/rubocop_1.49.gemfile
+++ b/gemfiles/rubocop_1.49.gemfile
@@ -10,5 +10,9 @@ gem "minitest"
 gem "rake"
 gem "rails", ">= 5.2"
 gem "rubocop", "~> 1.49.0"
+# This is a workaround to prevent the following error in RuboCop Rails 2.21.2.
+# https://github.com/toshimaru/rubocop-rails_config/actions/runs/6522833241/job/17712818757#step:4:85
+# This gem specification can be removed once a version resolving the issue is released.
+gem "rubocop-rails", "2.21.1"
 
 gemspec path: "../"

--- a/gemfiles/rubocop_1.50.gemfile
+++ b/gemfiles/rubocop_1.50.gemfile
@@ -10,5 +10,9 @@ gem "minitest"
 gem "rake"
 gem "rails", ">= 5.2"
 gem "rubocop", "~> 1.50.0"
+# This is a workaround to prevent the following error in RuboCop Rails 2.21.2.
+# https://github.com/toshimaru/rubocop-rails_config/actions/runs/6522833241/job/17712818757#step:4:85
+# This gem specification can be removed once a version resolving the issue is released.
+gem "rubocop-rails", "2.21.1"
 
 gemspec path: "../"

--- a/gemfiles/rubocop_1.51.gemfile
+++ b/gemfiles/rubocop_1.51.gemfile
@@ -10,5 +10,9 @@ gem "minitest"
 gem "rake"
 gem "rails", ">= 5.2"
 gem "rubocop", "~> 1.51.0"
+# This is a workaround to prevent the following error in RuboCop Rails 2.21.2.
+# https://github.com/toshimaru/rubocop-rails_config/actions/runs/6522833241/job/17712818757#step:4:85
+# This gem specification can be removed once a version resolving the issue is released.
+gem "rubocop-rails", "2.21.1"
 
 gemspec path: "../"

--- a/gemfiles/rubocop_1.52.gemfile
+++ b/gemfiles/rubocop_1.52.gemfile
@@ -10,5 +10,9 @@ gem "minitest"
 gem "rake"
 gem "rails", ">= 5.2"
 gem "rubocop", "~> 1.52.0"
+# This is a workaround to prevent the following error in RuboCop Rails 2.21.2.
+# https://github.com/toshimaru/rubocop-rails_config/actions/runs/6522833241/job/17712818757#step:4:85
+# This gem specification can be removed once a version resolving the issue is released.
+gem "rubocop-rails", "2.21.1"
 
 gemspec path: "../"

--- a/gemfiles/rubocop_1.53.gemfile
+++ b/gemfiles/rubocop_1.53.gemfile
@@ -10,5 +10,9 @@ gem "minitest"
 gem "rake"
 gem "rails", ">= 5.2"
 gem "rubocop", "~> 1.53.0"
+# This is a workaround to prevent the following error in RuboCop Rails 2.21.2.
+# https://github.com/toshimaru/rubocop-rails_config/actions/runs/6522833241/job/17712818757#step:4:85
+# This gem specification can be removed once a version resolving the issue is released.
+gem "rubocop-rails", "2.21.1"
 
 gemspec path: "../"

--- a/gemfiles/rubocop_1.54.gemfile
+++ b/gemfiles/rubocop_1.54.gemfile
@@ -10,5 +10,9 @@ gem "minitest"
 gem "rake"
 gem "rails", ">= 5.2"
 gem "rubocop", "~> 1.54.0"
+# This is a workaround to prevent the following error in RuboCop Rails 2.21.2.
+# https://github.com/toshimaru/rubocop-rails_config/actions/runs/6522833241/job/17712818757#step:4:85
+# This gem specification can be removed once a version resolving the issue is released.
+gem "rubocop-rails", "2.21.1"
 
 gemspec path: "../"

--- a/gemfiles/rubocop_1.55.gemfile
+++ b/gemfiles/rubocop_1.55.gemfile
@@ -10,5 +10,9 @@ gem "minitest"
 gem "rake"
 gem "rails", ">= 5.2"
 gem "rubocop", "~> 1.55.0"
+# This is a workaround to prevent the following error in RuboCop Rails 2.21.2.
+# https://github.com/toshimaru/rubocop-rails_config/actions/runs/6522833241/job/17712818757#step:4:85
+# This gem specification can be removed once a version resolving the issue is released.
+gem "rubocop-rails", "2.21.1"
 
 gemspec path: "../"

--- a/gemfiles/rubocop_1.56.gemfile
+++ b/gemfiles/rubocop_1.56.gemfile
@@ -10,5 +10,9 @@ gem "minitest"
 gem "rake"
 gem "rails", ">= 5.2"
 gem "rubocop", "~> 1.56.0"
+# This is a workaround to prevent the following error in RuboCop Rails 2.21.2.
+# https://github.com/toshimaru/rubocop-rails_config/actions/runs/6522833241/job/17712818757#step:4:85
+# This gem specification can be removed once a version resolving the issue is released.
+gem "rubocop-rails", "2.21.1"
 
 gemspec path: "../"


### PR DESCRIPTION
This is a workaround to prevent the following error in RuboCop Rails 2.21.2. https://github.com/toshimaru/rubocop-rails_config/actions/runs/6522833241/job/17712818757#step:4:85

`gem "rubocop-rails", "2.21.1"` specification can be removed once a version resolving the issue is released.