### PR TITLE
Update to plugins

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -1,9 +1,11 @@
-require:
+plugins:
   - rubocop-minitest
-  - rubocop-packaging
   - rubocop-performance
   - rubocop-rails
   - rubocop-md
+
+require:
+  - rubocop-packaging
 
 AllCops:
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop


### PR DESCRIPTION
fixes:

```
rubocop-minitest extension supports plugin, specify `plugins: rubocop-minitest` instead of `require: rubocop-minitest` in /home/superuser/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rubocop-rails_config-1.16.0/config/rails.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in /home/superuser/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rubocop-rails_config-1.16.0/config/rails.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in /home/superuser/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rubocop-rails_config-1.16.0/config/rails.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-md extension supports plugin, specify `plugins: rubocop-md` instead of `require: rubocop-md` in /home/superuser/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rubocop-rails_config-1.16.0/config/rails.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```