### PR TITLE
Bump rubocop-packaging to 0.6.0

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -1,11 +1,9 @@
 plugins:
   - rubocop-minitest
+  - rubocop-packaging
   - rubocop-performance
   - rubocop-rails
   - rubocop-md
-
-require:
-  - rubocop-packaging
 
 AllCops:
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop

--- a/rubocop-rails_config.gemspec
+++ b/rubocop-rails_config.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop-ast", ">= 1.38.0"
   spec.add_dependency "rubocop-md"
   spec.add_dependency "rubocop-minitest", "~> 0.37"
-  spec.add_dependency "rubocop-packaging", "~> 0.5"
+  spec.add_dependency "rubocop-packaging", "~> 0.6"
   spec.add_dependency "rubocop-performance", "~> 1.24"
   spec.add_dependency "rubocop-rails", "~> 2.30"
 end


### PR DESCRIPTION
Follow-up https://github.com/rails/rails/pull/54801

This PR bumps rubocop-packaging to 0.6.0 to use the new plugin-based version.